### PR TITLE
[BUGFIX] Use array_reverse to resort the rootline

### DIFF
--- a/Classes/Aspect/BreadcrumbListAspect.php
+++ b/Classes/Aspect/BreadcrumbListAspect.php
@@ -67,7 +67,7 @@ final class BreadcrumbListAspect implements AspectInterface
         }
 
         if (!empty($rootLine)) {
-            \sort($rootLine);
+            $rootLine = array_reverse($rootLine);
             $breadcrumbList = $this->buildBreadCrumbList($rootLine);
             $schemaManager->addType($breadcrumbList);
         }


### PR DESCRIPTION
The rows in $rootLine should not be resorted but reversed to generate a breadcrumb in valid order.

Resolves: https://github.com/brotkrueml/schema/issues/32