### PR TITLE
[BUGFIX] Only auto-generate breadcrumb in case there is none

### DIFF
--- a/Classes/EventListener/AddBreadcrumbList.php
+++ b/Classes/EventListener/AddBreadcrumbList.php
@@ -13,6 +13,7 @@ namespace Brotkrueml\Schema\EventListener;
 
 use Brotkrueml\Schema\Core\Model\TypeInterface;
 use Brotkrueml\Schema\Event\RenderAdditionalTypesEvent;
+use Brotkrueml\Schema\Manager\SchemaManager;
 use Brotkrueml\Schema\Type\TypeFactory;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Domain\Repository\PageRepository;
@@ -33,20 +34,23 @@ final class AddBreadcrumbList
 
     private ExtensionConfiguration $extensionConfiguration;
     private ContentObjectRenderer $contentObjectRenderer;
+    private SchemaManager $schemaManager;
 
     public function __construct(
         ContentObjectRenderer $contentObjectRenderer,
-        ExtensionConfiguration $configuration
+        ExtensionConfiguration $configuration,
+        SchemaManager $schemaManager
     ) {
         $this->contentObjectRenderer = $contentObjectRenderer;
         $this->extensionConfiguration = $configuration;
+        $this->schemaManager = $schemaManager;
     }
 
     public function __invoke(RenderAdditionalTypesEvent $event): void
     {
         $configuration = $this->extensionConfiguration->get('schema');
         $shouldEmbedBreadcrumbMarkup = (bool)$configuration['automaticBreadcrumbSchemaGeneration'];
-        if (! $shouldEmbedBreadcrumbMarkup) {
+        if (! $shouldEmbedBreadcrumbMarkup || $this->schemaManager->hasBreadcrumbList()) {
             return;
         }
 

--- a/Classes/Manager/SchemaManager.php
+++ b/Classes/Manager/SchemaManager.php
@@ -70,6 +70,20 @@ final class SchemaManager implements SingletonInterface
         return $this;
     }
 
+    /**
+     * @param class-string $className
+     * @return bool
+     */
+    public function hasType(string $className): bool
+    {
+        foreach ($this->types as $type) {
+            if (is_a($type, $className)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private function isWebPageType(TypeInterface $type): bool
     {
         return $type instanceof WebPageTypeInterface;
@@ -104,6 +118,11 @@ final class SchemaManager implements SingletonInterface
         }
 
         $this->webPage = $webPage;
+    }
+
+    public function hasBreadcrumbList(): bool
+    {
+        return $this->breadcrumbLists !== [];
     }
 
     private function isBreadCrumbList(TypeInterface $type): bool


### PR DESCRIPTION
Extension configuration `automaticBreadcrumbSchemaGeneration` lead to the situation that a breadcrumb (provided via Fluid templates), had been overriden by `AddBreadcrumbList`.

Auto-generation now only continues, in case `SchemaManager` does not have any `BreadcrumbList`, yet.

Fixes: #104