### PR TITLE
[BUGFIX] fix fluid viewhelper namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@
 
 ## Versions and support
 
-| Latest release | TYPO3       | PHP   | Updates will contain                                 |
-|----------------|-------------|-------|------------------------------------------------------|
-| 3.x            | 11.5 - 13.4 | ≥ 8.1 | Features, schema.org updates, security and bug fixes |
-| 2.x            | 10.4 - 12.4 | ≥ 7.4 | End of life                                          |
-| 1.x            | 9.5 - 11.5  | ≥ 7.2 | End of life                                          |
+| Latest release | TYPO3              | PHP   | Updates will contain                                 |
+|----------------|--------------------|-------|------------------------------------------------------|
+| 3.x            | 11.5 / 12.4 / 13.4 | ≥ 8.1 | Features, schema.org updates, security and bug fixes |
+| 2.x            | 10.4 / 11.5 / 12.4 | ≥ 7.4 | End of life                                          |
+| 1.x            | 9.5 / 10.4 / 11.5  | ≥ 7.2 | End of life                                          |
 
 [Documentation](https://docs.typo3.org/p/brotkrueml/schema/main/en-us/) |
 [Translation](https://crowdin.com/project/typo3-extension-schema) |


### PR DESCRIPTION
TYPO3 v13 throws an error if namespace starts with https://

<img width="768" alt="Bildschirmfoto 2024-10-22 um 02 47 20" src="https://github.com/user-attachments/assets/a72e9f6a-2115-4b3f-a93f-c68143864f88">
