### PR TITLE
Resolve additional properties map at compile time

### DIFF
--- a/Classes/DependencyInjection/AdditionalPropertiesPass.php
+++ b/Classes/DependencyInjection/AdditionalPropertiesPass.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Brotkrueml\Schema\DependencyInjection;
 
+use Brotkrueml\Schema\Core\AdditionalPropertiesInterface;
 use Brotkrueml\Schema\Type\AdditionalPropertiesProvider;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -31,8 +32,14 @@ final readonly class AdditionalPropertiesPass implements CompilerPassInterface
         }
 
         $providerDefinition = $container->getDefinition(AdditionalPropertiesProvider::class)->setPublic(true);
+
+        $additionalPropertiesByType = [];
         foreach (\array_keys($container->findTaggedServiceIds($this->tagName)) as $id) {
-            $providerDefinition->addMethodCall('add', [$id]);
+            /** @var AdditionalPropertiesInterface $instance */
+            $instance = new $id();
+            $additionalPropertiesByType[$instance->getType()][] = $id;
         }
+
+        $providerDefinition->setArgument('$additionalPropertiesByType', $additionalPropertiesByType);
     }
 }

--- a/Classes/Type/AdditionalPropertiesProvider.php
+++ b/Classes/Type/AdditionalPropertiesProvider.php
@@ -16,36 +16,26 @@ use Brotkrueml\Schema\Core\AdditionalPropertiesInterface;
 /**
  * @internal
  */
-final class AdditionalPropertiesProvider
+final readonly class AdditionalPropertiesProvider
 {
     /**
-     * @var array<non-empty-string, list<class-string<AdditionalPropertiesInterface>>>
+     * @param array<non-empty-string, list<class-string<AdditionalPropertiesInterface>>> $additionalPropertiesByType
      */
-    private array $additionalProperties = [];
-
-    /**
-     * @param class-string<AdditionalPropertiesInterface> $className
-     */
-    public function add(string $className): void
-    {
-        $type = (new $className())->getType();
-        if (! isset($this->additionalProperties[$type])) {
-            $this->additionalProperties[$type] = [];
-        }
-        $this->additionalProperties[$type][] = $className;
-    }
+    public function __construct(
+        private array $additionalPropertiesByType = [],
+    ) {}
 
     /**
      * @return list<non-empty-string>
      */
     public function getForType(string $type): array
     {
-        if (! isset($this->additionalProperties[$type])) {
+        if (! isset($this->additionalPropertiesByType[$type])) {
             return [];
         }
 
         $additionalPropertiesForType = [];
-        foreach ($this->additionalProperties[$type] as $className) {
+        foreach ($this->additionalPropertiesByType[$type] as $className) {
             $additionalPropertiesForType = [
                 ...$additionalPropertiesForType,
                 ...(new $className())->getAdditionalProperties(),

--- a/Tests/Unit/Core/Model/AbstractTypeTest.php
+++ b/Tests/Unit/Core/Model/AbstractTypeTest.php
@@ -71,8 +71,9 @@ final class AbstractTypeTest extends TestCase
                 ];
             }
         };
-        $additionalPropertiesProvider = new AdditionalPropertiesProvider();
-        $additionalPropertiesProvider->add($additionalProperties::class);
+        $additionalPropertiesProvider = new AdditionalPropertiesProvider([
+            'Thing' => [$additionalProperties::class],
+        ]);
 
         $subject = new Thing($additionalPropertiesProvider);
 
@@ -101,8 +102,9 @@ final class AbstractTypeTest extends TestCase
                 ];
             }
         };
-        $additionalPropertiesProvider = new AdditionalPropertiesProvider();
-        $additionalPropertiesProvider->add($additionalProperties::class);
+        $additionalPropertiesProvider = new AdditionalPropertiesProvider([
+            'Thing' => [$additionalProperties::class],
+        ]);
 
         $subject = new Thing($additionalPropertiesProvider);
 

--- a/Tests/Unit/Type/AdditionalPropertiesProviderTest.php
+++ b/Tests/Unit/Type/AdditionalPropertiesProviderTest.php
@@ -22,29 +22,33 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(AdditionalPropertiesProvider::class)]
 final class AdditionalPropertiesProviderTest extends TestCase
 {
-    private AdditionalPropertiesProvider $subject;
-
-    protected function setUp(): void
+    #[Test]
+    public function getForTypeReturnsEmptyArrayWhenNoTypesAreRegistered(): void
     {
-        $this->subject = new AdditionalPropertiesProvider();
+        $subject = new AdditionalPropertiesProvider();
+
+        self::assertSame([], $subject->getForType('NonExisting'));
     }
 
     #[Test]
-    public function getForTypeReturnsEmptyArrayIfTypeIsNotAvailable(): void
+    public function getForTypeReturnsEmptyArrayWhenTypeIsNotRegistered(): void
     {
-        $actual = $this->subject->getForType('NonExisting');
+        $subject = new AdditionalPropertiesProvider([
+            'Person' => [Person1::class],
+        ]);
 
-        self::assertSame([], $actual);
+        self::assertSame([], $subject->getForType('NonExisting'));
     }
 
     #[Test]
-    public function getForTypeReturnsPreviouslyAddedClassesCorrectly(): void
+    public function getForTypeReturnsRegisteredPropertiesCorrectly(): void
     {
-        $this->subject->add(Person1::class);
-        $this->subject->add(Person2::class);
-        $this->subject->add(Event::class);
+        $subject = new AdditionalPropertiesProvider([
+            'Person' => [Person1::class, Person2::class],
+            'Event' => [Event::class],
+        ]);
 
-        $actual = $this->subject->getForType('Person');
+        $actual = $subject->getForType('Person');
 
         self::assertCount(3, $actual);
         self::assertSame('additional-person-property-1', $actual[0]);


### PR DESCRIPTION
Fixes #156.

`AdditionalPropertiesPass` emits one `addMethodCall('add', [$className])` for every tagged class. Symfony compiles these into the `AdditionalPropertiesProvider` service factory, so each service construction calls `add()` once per tagged class — and `add()` does `(new $className())->getType()`. In a TYPO3 v13 site with the full schema.org set, that is ~600 class instantiations per request.

The mapping is the same on every request, so this commit moves the work into the compiler pass: instantiate each tagged class once at container build time, build the type → classes map, and pass it to the provider via a constructor argument. `add()` is removed.

`AdditionalPropertiesProvider` is marked `@internal`, so the constructor signature change should be fine.

### Test updates

- `Tests/Unit/Type/AdditionalPropertiesProviderTest`: rewritten to construct the provider with the pre-built map; added one extra case for "type not in the map".
- `Tests/Unit/Core/Model/AbstractTypeTest`: two test cases updated to use the new constructor shape (they used the old `add()`).

### Verification

- Targeted unit test: `phpunit Tests/Unit/Type/AdditionalPropertiesProviderTest.php` → 3 tests, 6 assertions, OK.
- Full unit suite passes (one pre-existing failure remains in `AddWebPageTypeTest::webPageTypeHasExpiresSetIfEndTimePagePropertiesIsDefined` — a timezone test, unrelated to this change).
- In a real TYPO3 v13 site, the 600+ `AdditionalPropertiesProvider::add` calls disappear from the xhprof trace and rendered JSON-LD is unchanged.
